### PR TITLE
Fix naming typo

### DIFF
--- a/src/dragger.py
+++ b/src/dragger.py
@@ -31,8 +31,8 @@ class Dragger:
         self.piece = None
         self.dragging = False
 
-    def render_peace_motion(self, surface: pygame.Surface):
-        """ Create motion while 'holding' a peace """
+    def render_piece_motion(self, surface: pygame.Surface):
+        """Create motion while 'holding' a piece."""
         self.piece.set_texture(size=128)
         img = pygame.image.load(self.piece.texture)
         img_center = self.mouse_x, self.mouse_y

--- a/src/main.py
+++ b/src/main.py
@@ -46,7 +46,7 @@ class Main:
 
         if self.game.dragger.dragging:
             self.game.dragger.update_mouse(event.pos)
-            self.game.dragger.render_peace_motion(self.screen)
+            self.game.dragger.render_piece_motion(self.screen)
         else:
             pass
 
@@ -151,7 +151,7 @@ class Main:
 
             # Update piece blit while drugging
             if self.game.dragger.dragging:
-                self.game.dragger.render_peace_motion(self.screen)
+                self.game.dragger.render_piece_motion(self.screen)
 
             for event in pygame.event.get():
                 self.event_manager(event)


### PR DESCRIPTION
## Summary
- fix typo in drag motion function name
- update usage in main

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6840161f168c832db31a3624adb75b53