### PR TITLE
Fix comment typos

### DIFF
--- a/src/dragger.py
+++ b/src/dragger.py
@@ -32,7 +32,7 @@ class Dragger:
         self.dragging = False
 
     def render_peace_motion(self, surface: pygame.Surface):
-        """ Create motion while 'holding' a peace """
+        """Create motion while 'holding' a piece"""
         self.piece.set_texture(size=128)
         img = pygame.image.load(self.piece.texture)
         img_center = self.mouse_x, self.mouse_y

--- a/src/game.py
+++ b/src/game.py
@@ -88,7 +88,7 @@ class Game:
         self._draw_tail(surface)
 
     def render_pieces(self, surface: pygame.Surface):
-        # If peace was clicked it should produce possible moves. TODO
+        # If piece was clicked it should produce possible moves. TODO
         
         for row in range(ROWS):
             for col in range(COLUMNS):

--- a/src/main.py
+++ b/src/main.py
@@ -77,7 +77,7 @@ class Main:
             return
         
     def _do_event_unclick(self, event: pygame.event) -> None:
-            # Leave peace on the new place if been dragged
+            # Leave piece on the new place if been dragged
             if self.game.dragger.dragging:
                 clicked_row = event.pos[1] // SQUARE_SIZE
                 clicked_col = event.pos[0] // SQUARE_SIZE
@@ -149,7 +149,7 @@ class Main:
             self.game.render_board(self.screen)
             self.game.render_pieces(self.screen)
 
-            # Update piece blit while drugging
+            # Update piece blit while dragging
             if self.game.dragger.dragging:
                 self.game.dragger.render_peace_motion(self.screen)
 


### PR DESCRIPTION
## Summary
- clean up comments referencing dragging a piece
- update docstring for `render_peace_motion`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68401639809c832db3b4520cce249910