### PR TITLE
Fix sound method

### DIFF
--- a/src/game.py
+++ b/src/game.py
@@ -128,9 +128,10 @@ class Game:
         
         # MISSING THE BOARD
         if not (0 <= cur_row <= 7 and 0 <= cur_col <= 7):
+            # Play capture sound when a piece is dragged off the board
+            self._make_sound(past_row, past_col)
             board.destroy(past_row, past_col)  # Unfortunately destroys the piece (Might delete later)
             self.moves_done += 1
-            self.make_sound("capture")
             return False
 
         # SAME SQUARE
@@ -164,7 +165,7 @@ class Game:
         else:
             sound = pygame.mixer.Sound(r"assets/sounds/move.wav")
             
-        pygame.mixer.Sound.play(sound)
+        sound.play()
         return
     
     @staticmethod


### PR DESCRIPTION
## Summary
- play the capture sound on out-of-bounds drag
- fix `_make_sound` to use `sound.play()` instead of `pygame.mixer.Sound.play`

## Testing
- `python -m py_compile src/game.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6840163baaf4832dab8bcc5fa5ac6d92